### PR TITLE
- `nix_build()`: fix defensive check message

### DIFF
--- a/R/find_rev.R
+++ b/R/find_rev.R
@@ -426,9 +426,9 @@ nix_build <- function(project_path = ".",
   nix_file <- file.path(project_path, "default.nix")
   
   stopifnot(
-    "Argument `nix_file` must be character of length 1." =
-      is.character(nix_file) && length(nix_file) == 1L,
-    "`nix_file` does not exist. Please use a valid path." =
+    "`project_path` must be character of length 1." =
+      is.character(project_path) && length(project_path) == 1L,
+    "`project_path` has no `default.nix` file. Use one that contains `default.nix`" =
       file.exists(nix_file),
     "`nix-build` not available. To install, we suggest you follow https://zero-to-nix.com/start/install ." =
       isTRUE(has_nix_build)

--- a/dev/build_envs.Rmd
+++ b/dev/build_envs.Rmd
@@ -517,9 +517,9 @@ nix_build <- function(project_path = ".",
   nix_file <- file.path(project_path, "default.nix")
   
   stopifnot(
-    "Argument `nix_file` must be character of length 1." =
-      is.character(nix_file) && length(nix_file) == 1L,
-    "`nix_file` does not exist. Please use a valid path." =
+    "`project_path` must be character of length 1." =
+      is.character(project_path) && length(project_path) == 1L,
+    "`project_path` has no `default.nix` file. Use one that contains `default.nix`" =
       file.exists(nix_file),
     "`nix-build` not available. To install, we suggest you follow https://zero-to-nix.com/start/install ." =
       isTRUE(has_nix_build)


### PR DESCRIPTION
@b-rodrigues I just noticed that the defensive check error in `nix_build()` was still printing a `nix_file` quoting error message. This fixes accordingly the message using `project_path` and `default.nix` in the message.

Since this does not affect the behavior of `nix_build()` but rather just is the error message, I think we do not need to increment versioning using "patch". However, if you want to increment to 0.1.2, I am very happy to do so and update news accordingly