### PR TITLE
`default.nix` use `--vanilla` to fix nix R CI shell error

### DIFF
--- a/inst/extdata/default.nix
+++ b/inst/extdata/default.nix
@@ -41,5 +41,5 @@
     buildInputs = [
        my-r
         ];
-    shellHook = "R";
+    shellHook = "R --vanilla";
 }


### PR DESCRIPTION
addresses #56 ; adapt shellHook