### PR TITLE
fix locale warnings by setting envvars in nix

### DIFF
--- a/inst/extdata/default.nix
+++ b/inst/extdata/default.nix
@@ -36,6 +36,12 @@ let
   in
   pkgs.mkShell {
     LOCALE_ARCHIVE = if pkgs.system == "x86_64-linux" then "${pkgs.glibcLocalesUtf8}/lib/locale/locale-archive" else "";
+    LANG = "en_US.UTF-8";
+    LC_ALL = "en_US.UTF-8";
+    LC_TIME = "en_US.UTF-8";
+    LC_MONETARY = "en_US.UTF-8";
+    LC_PAPER = "en_US.UTF-8";
+    LC_MEASUREMENT = "en_US.UTF-8";
     buildInputs = [ git_archive_pkgs   system_packages  ];
       shellHook = "R --vanilla";
   }


### PR DESCRIPTION
fixes #50 