### PR TITLE
fix missing `pkgs.mkShell` when `shell_hook = NULL`

### DIFF
--- a/R/find_rev.R
+++ b/R/find_rev.R
@@ -517,9 +517,9 @@ flag_rpkgs
 
   flag_rstudio <- if (ide == "rstudio") "rstudio_pkgs" else  ""
 
-  shell_hook <- if (!is.null(shell_hook)) {
+  shell_hook <- if (!is.null(shell_hook) && nzchar(shell_hook)) {
     paste0('shellHook = "', shell_hook, '";')
-  }
+  } else {''}
 
   # Generate the shell
   generate_shell <- function(flag_git_archive,

--- a/dev/build_envs.Rmd
+++ b/dev/build_envs.Rmd
@@ -601,9 +601,9 @@ flag_rpkgs
 
   flag_rstudio <- if (ide == "rstudio") "rstudio_pkgs" else  ""
 
-  shell_hook <- if (!is.null(shell_hook)) {
+  shell_hook <- if (!is.null(shell_hook) && nzchar(shell_hook)) {
     paste0('shellHook = "', shell_hook, '";')
-  }
+  } else {''}
 
   # Generate the shell
   generate_shell <- function(flag_git_archive,


### PR DESCRIPTION
example before this patch:

```{sh}
spectral-cockpit@localhost  ~/git/philipp-baumann/rix_tests   main ±  cat default.nix 
# This file was generated by the {rix} R package v0.4.0 on 2023-10-06
# with following call:
# >rix(r_ver = "7131f3c223a2d799568e4b278380cd9dac2b8579",
#  > system_pkgs = c("nix",
#  > "radianWrapper",
#  > "quarto"),
#  > git_pkgs = list(list(package_name = "rix",
#  > repo_url = "https://github.com/b-rodrigues/rix",
#  > branch_name = "master",
#  > commit = "15d82addb3b60363a2d162be84be2cad74180efc")),
#  > ide = "code",
#  > overwrite = TRUE,
#  > shell_hook = NULL)
# It uses nixpkgs' revision 7131f3c223a2d799568e4b278380cd9dac2b8579 for reproducibility purposes
# which will install R version latest
# Report any issues to https://github.com/b-rodrigues/rix
let
 pkgs = import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/7131f3c223a2d799568e4b278380cd9dac2b8579.tar.gz") {};
 rpkgs = builtins.attrValues {
  inherit (pkgs.rPackages) languageserver;
};
 git_archive_pkgs = [(pkgs.rPackages.buildRPackage {
    name = "rix";
    src = pkgs.fetchgit {
      url = "https://github.com/b-rodrigues/rix";
      branchName = "master";
      rev = "15d82addb3b60363a2d162be84be2cad74180efc";
      sha256 = "sha256-/qX7Z4wk9slr/SYJLxnwvLYZh6UgZDcLald1HN52BNk=";
    };
    propagatedBuildInputs = builtins.attrValues {
      inherit (pkgs.rPackages) httr jsonlite sys;
    };
  }) ];
  system_packages = builtins.attrValues {
  inherit (pkgs) R glibcLocalesUtf8 nix radianWrapper quarto;
};
  
 spectral-cockpit@localhost  ~/git/philipp-baumann/rix_tests   main ±  nix-build .
error: syntax error, unexpected end of file

       at /home/spectral-cockpit/git/philipp-baumann/rix_tests/default.nix:36:3:

           35|   inherit (pkgs) R glibcLocalesUtf8 nix radianWrapper quarto;
           36| };
             |   ^
           37|
 ✘ spectral-cockpit@localhost  ~/git/philipp-baumann/rix_tests   main ±  radian
R version 4.2.1 (2022-06-23) -- "Funny-Looking Kid"
Platform: x86_64-pc-linux-gnu (64-bit)

r$> library("rix")

r$> sessioninfo::session_info()
─ Session info ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 setting  value
 version  R version 4.2.1 (2022-06-23)
 os       Rocky Linux 8.7 (Green Obsidian)
 system   x86_64, linux-gnu
 ui       X11
 language (EN)
 collate  en_US.UTF-8
 ctype    en_US.UTF-8
 tz       Europe/Zurich
 date     2023-10-06
 pandoc   2.0.6 @ /usr/bin/pandoc

─ Packages ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 package     * version date (UTC) lib source
 cli           3.6.1   2023-03-23 [1] CRAN (R 4.2.1)
 httr          1.4.7   2023-08-15 [1] CRAN (R 4.2.1)
 jsonlite      1.8.7   2023-06-29 [1] CRAN (R 4.2.1)
 R6            2.5.1   2021-08-19 [1] CRAN (R 4.2.1)
 rix         * 0.4.0   2023-10-01 [1] Github (b-rodrigues/rix@15d82ad)
 sessioninfo   1.2.2   2021-12-06 [1] CRAN (R 4.2.1)

 [1] /home/spectral-cockpit/R/x86_64-pc-linux-gnu-library/4.2
 [2] /opt/R/4.2.1/lib/R/library

─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
```