### PR TITLE
"older" nixpkgs revisions. Import `glibcLocales` to fix `glibcLocalesUtf8` attribute not found

### DIFF
--- a/R/detect_os.R
+++ b/R/detect_os.R
@@ -24,7 +24,7 @@ detect_os <- function(){
 generate_locale_archive <- function(os){
   os <- detect_os()
   if (os == "Linux" || os == "Darwin") {
-    'LOCALE_ARCHIVE = if pkgs.system == \"x86_64-linux\" then  \"${pkgs.glibcLocalesUtf8}/lib/locale/locale-archive\" else \"\";'
+    'LOCALE_ARCHIVE = if pkgs.system == \"x86_64-linux\" then  \"${pkgs.glibcLocales}/lib/locale/locale-archive\" else \"\";'
   } else {
     stop("Operating System unsupported")
   }

--- a/R/find_rev.R
+++ b/R/find_rev.R
@@ -290,10 +290,7 @@ fetchpkgs  <- function(git_pkgs, archive_pkgs){
 #'   If there are good reasons to not stick to the default, you can set your
 #'   preferred locale variables via 
 #'   `options(rix.nix_locale_variables = list(LANG = "de_CH.UTF-8", <...>)`
-#'   and the aforementioned locale variable names. However, you should use 
-#'   UTF-8 locales since we import the `glibcLocalesUtf8` set only, to not 
-#'   download the full set of locales and thereby keep the size reasonably
-#'   small.
+#'   and the aforementioned locale variable names.
 #' @export
 rix <- function(r_ver = "latest",
                 r_pkgs = NULL,
@@ -467,7 +464,7 @@ tex_pkgs)
   # to add it.
   generate_system_pkgs <- function(system_pkgs){
     sprintf('system_packages = builtins.attrValues {
-  inherit (pkgs) R glibcLocalesUtf8 %s;
+  inherit (pkgs) R glibcLocales %s;
 };
 ',
 get_system_pkgs(system_pkgs))

--- a/dev/build_envs.Rmd
+++ b/dev/build_envs.Rmd
@@ -374,10 +374,7 @@ you use another IDE, you can leave the "ide" argument blank:
 #'   If there are good reasons to not stick to the default, you can set your
 #'   preferred locale variables via 
 #'   `options(rix.nix_locale_variables = list(LANG = "de_CH.UTF-8", <...>)`
-#'   and the aforementioned locale variable names. However, you should use 
-#'   UTF-8 locales since we import the `glibcLocalesUtf8` set only, to not 
-#'   download the full set of locales and thereby keep the size reasonably
-#'   small.
+#'   and the aforementioned locale variable names.
 #' @export
 rix <- function(r_ver = "latest",
                 r_pkgs = NULL,
@@ -551,7 +548,7 @@ tex_pkgs)
   # to add it.
   generate_system_pkgs <- function(system_pkgs){
     sprintf('system_packages = builtins.attrValues {
-  inherit (pkgs) R glibcLocalesUtf8 %s;
+  inherit (pkgs) R glibcLocales %s;
 };
 ',
 get_system_pkgs(system_pkgs))

--- a/dev/get_os.Rmd
+++ b/dev/get_os.Rmd
@@ -43,7 +43,7 @@ This function adds deals with locale on Linux (and WSL2):
 generate_locale_archive <- function(os){
   os <- detect_os()
   if (os == "Linux" || os == "Darwin") {
-    'LOCALE_ARCHIVE = if pkgs.system == \"x86_64-linux\" then  \"${pkgs.glibcLocalesUtf8}/lib/locale/locale-archive\" else \"\";'
+    'LOCALE_ARCHIVE = if pkgs.system == \"x86_64-linux\" then  \"${pkgs.glibcLocales}/lib/locale/locale-archive\" else \"\";'
   } else {
     stop("Operating System unsupported")
   }

--- a/man/rix.Rd
+++ b/man/rix.Rd
@@ -95,8 +95,5 @@ reproducibility by default in Nix environments created with \code{rix()}.
 If there are good reasons to not stick to the default, you can set your
 preferred locale variables via
 \verb{options(rix.nix_locale_variables = list(LANG = "de_CH.UTF-8", <...>)}
-and the aforementioned locale variable names. However, you should use
-UTF-8 locales since we import the \code{glibcLocalesUtf8} set only, to not
-download the full set of locales and thereby keep the size reasonably
-small.
+and the aforementioned locale variable names.
 }


### PR DESCRIPTION
addresses #95 