### PR TITLE
`with_nix()` and `nix_shell()` in-session fix `PATH` for RStudio on macOS; improve docs

### DIFF
--- a/dev/build_envs.Rmd
+++ b/dev/build_envs.Rmd
@@ -1126,6 +1126,55 @@ environment.
 ```{r, function-with-nix}
 
 #' Evaluate function in R or shell command via `nix-shell` environment
+#' 
+#' 1. Evaluate a function in R or a shell command via the `nix-shell`
+#'   environment (Nix expression for custom software libraries; involving pinned
+#'   versions of R and R packages via Nixpkgs)
+#' 2. If no error, return the result object of `expr` in `with_nix()` into the
+#'   current R session.
+#'
+#'
+#'
+#' `with_nix()` gives you the power of evaluating a main function `expr` 
+#' and its function call stack that are defined in the current R session
+#' in an encapsulated nix-R session defined by Nix expression (`default.nix`),
+#' which is located in at a distinct project path (`project_path`). It is for 
+#' example useful for the following purposes.
+#' 
+#' 1. test compatibility of custom R code and software/package dependencies in
+#'   development and production environments
+#' 2. directly stream outputs (returned objects), messages and errors from any
+#'   command line tool offered in Nixpkgs into an R session.
+#' 3. Test if evolving R packages change their behavior for given unchanged
+#'   R code, and whether they give identical results or not.
+#' 
+#' `with_nix()` can evaluate both R code from a nix-R session within
+#' another nix-R session, and also from a host R session (i.e., on macOS or
+#' Linux) within a specific nix-R  session. This feature is useful for testing
+#' the reproducibility and the compatibility of two and more sets (if repeatedly
+#' in isolated folders) of different software environments.
+#' 
+#' This solution is very convenient because it gives direct feedback in 
+#' read-eval-print-loop style, but from the very reproducible
+#' infrastructure-as-code approach offered by Nix and Nixpkgs. You don't need
+#' extra efforts such as setting up DevOps tooling like Docker and domain
+#' specific tools like {renv} to control complex software environments in R and
+#' any other language.
+#' 
+#' To do its job, `with_nix()` heavily relies on patterns that manipulate
+#' language expressions (aka computing on the language) offered in base R as well as
+#' the {codetools} package by Luke Tierney. Some of the key steps that are
+#' done behind the scene:
+#' 1. recursively find and export global objects (globals) in the call
+#' stack of `expr` as well as propagate R package environments found.
+#' 2. Serialize (save to disk) and deserialize (read from disk) dependent
+#'  data structures as `.Rds` with necessary function arguments provided,
+#'  any relevant globals in the call stack, packages, and `expr` outputs 
+#'  returned in a temporary directory.
+#' 3. Use pure `nix-shell` environments to execute a R code script 
+#'   reconstructed catching expressions with quoting; it is launched by commands
+#'  like this via `{sys}` by Jeroen Ooms:
+#'  `nix-shell --pure --run "Rscript --vanilla"`.
 #'
 #' @param expr Single R function or call, shell command, or list of them.
 #' @param program String stating where to evaluate the expression. Either `"R"`,
@@ -1143,8 +1192,28 @@ with_nix <- function(expr,
                      exec_mode = c("blocking", "non-blocking"),
                      project_path = ".",
                      message_type = c("simple", "verbose")) {
+  nix_file <- file.path(project_path, "default.nix")
+  stopifnot(
+    "`project_path` must be character of length 1." =
+      is.character(project_path) && length(project_path) == 1L,
+    "`project_path` has no `default.nix` file. Use one that contains `default.nix`" =
+      file.exists(nix_file),
+    "`message_type` must be character." = is.character(message_type),
+    "`expr` needs to be a call or function" = is.function(expr) || is.call(expr)
+  )
+  
+  # ad-hoc solution for RStudio's limitation that R sessions cannot yet inherit
+  # proper `PATH` from custom `.Rprofile` on macOS (2023-01-17)
+  # adjust `PATH` to include `/nix/var/nix/profiles/default/bin`
+  if (isTRUE(is_rstudio_session()) && isFALSE(is_nix_rsession())) {
+    set_nix_path()
+  }
+  
   has_nix_shell <- nix_shell_available() # TRUE if yes, FALSE if no
-  if (!has_nix_shell) {
+  stopifnot("`nix-shell` not available. To install, we suggest you follow https://zero-to-nix.com/start/install ." =
+    isTRUE(has_nix_shell))
+  
+  if (isFALSE(has_nix_shell)) {
     stop(
       paste0("`nix-shell` is needed but is not available in your current ",
         "shell environment.\n",
@@ -1161,18 +1230,7 @@ with_nix <- function(expr,
       call. = FALSE
     )
   }
-  nix_file <- file.path(project_path, "default.nix")
   
-  stopifnot(
-    "`project_path` must be character of length 1." =
-      is.character(project_path) && length(project_path) == 1L,
-    "`project_path` has no `default.nix` file. Use one that contains `default.nix`" =
-      file.exists(nix_file),
-    "`message_type` must be character." = is.character(message_type),
-    "`nix-shell` not available. To install, we suggest you follow https://zero-to-nix.com/start/install ." =
-      isTRUE(has_nix_shell),
-    "`expr` needs to be a call or function" = is.function(expr) || is.call(expr)
-  )
   program <- match.arg(program)
   exec_mode <- match.arg(exec_mode)
   message_type <- match.arg(message_type)

--- a/dev/build_envs.Rmd
+++ b/dev/build_envs.Rmd
@@ -1127,6 +1127,8 @@ environment.
 
 #' Evaluate function in R or shell command via `nix-shell` environment
 #' 
+#' This function needs an installation of Nix. `with_nix()` has two effects
+#' to run code in isolated and reproducible environments.
 #' 1. Evaluate a function in R or a shell command via the `nix-shell`
 #'   environment (Nix expression for custom software libraries; involving pinned
 #'   versions of R and R packages via Nixpkgs)
@@ -1161,12 +1163,27 @@ environment.
 #' specific tools like {renv} to control complex software environments in R and
 #' any other language.
 #' 
+#' #' `with_nix()` can evaluate both R code from a nix-R session within
+#' another nix-R session, and also from a host R session (i.e., on macOS or
+#' Linux) within a specific nix-R session. This feature is useful for testing
+#' the reproducibility and compatibility of given code across different software
+#' environments. If testing of different sets of environments is necessary, you
+#' can easily do so by providing Nix expressions in custom `.nix` or
+#' `default.nix` files in different subfolders of the project.
+#' 
+#' This solution is very convenient because it gives direct feedback in 
+#' read-eval-print-loop style, which gives a direct interface to the very 
+#' reproducible infrastructure-as-code approach offered by Nix and Nixpkgs. You
+#' don't need extra efforts such as setting up DevOps tooling like Docker and
+#' domain specific tools like {renv} to control complex software environments in
+#' R and any other language.
+#' 
 #' To do its job, `with_nix()` heavily relies on patterns that manipulate
-#' language expressions (aka computing on the language) offered in base R as well as
-#' the {codetools} package by Luke Tierney. Some of the key steps that are
-#' done behind the scene:
-#' 1. recursively find and export global objects (globals) in the call
-#' stack of `expr` as well as propagate R package environments found.
+#' language expressions (aka computing on the language) offered in base R as
+#' well as the {codetools} package by Luke Tierney. Some of the key steps that 
+#' are done behind the scene:
+#' 1. recursively find, classify, and export global objects (globals) in the 
+#' call stack of `expr` as well as propagate R package environments found.
 #' 2. Serialize (save to disk) and deserialize (read from disk) dependent
 #'  data structures as `.Rds` with necessary function arguments provided,
 #'  any relevant globals in the call stack, packages, and `expr` outputs 
@@ -1176,10 +1193,11 @@ environment.
 #'  like this via `{sys}` by Jeroen Ooms:
 #'  `nix-shell --pure --run "Rscript --vanilla"`.
 #'
-#' @param expr Single R function or call, shell command, or list of them.
+#' @param expr Single R function or call, or character vector with shell command
+#' element optionally followed by command arguments (one flag per element).
 #' @param program String stating where to evaluate the expression. Either `"R"`,
 #' the default, or `"shell"`. `where = "R"` will evaluate the expression via
-#' `RScript` and `where = "shell"` will run in `nix-shell`.
+#' `RScript` and `where = "shell"` will run the system command in `nix-shell`.
 #' @param message_type String how detailed output is. Currently, there is 
 #' either `"simple"` (default) or `"verbose"`, which shows the script that runs
 #' via `nix-shell`.
@@ -1187,6 +1205,36 @@ environment.
 #' @return
 #' @importFrom codetools findGlobals checkUsage
 #' @export
+#' @return 
+#' - if `program = "R"`, R object returned by function given in `expr`
+#' when evaluated via the R environment in `nix-shell` defined by Nix 
+#' expression.
+#' - if `program = "shell"`, character vector of standard output (stdout)
+#' of `expr` command sent to a command line interface provided by a Nix package.
+#' @examples
+#' \dontrun{
+#' # create an isolated, runtime-pure R setup via Nix
+#' project_path <- "./sub_shell"
+#' init(
+#'   project_path = project_path,
+#'   rprofile_action = "create_missing"
+#' )
+#' # generate nix environment in `default.nix`
+#' rix(
+#'   r_ver = "4.2.0",
+#'   project_path = project_path
+#' )
+#' # evaluate function in Nix-R environment via `nix-shell` and `Rscript`,
+#' # stream messages, and bring output back to current R session
+#' out <- with_nix(
+#'   expr = function(mtcars) nrow(mtcars),
+#'   program = "R", exec_mode = "non-blocking", project_path = project_path,
+#'   message_type = "simple"
+#' )
+#' 
+#' # There no limit in the complexity of function call stacks that `with_nix()`
+#' # can possibly handle
+#' }
 with_nix <- function(expr,
                      program = c("R", "shell"),
                      exec_mode = c("blocking", "non-blocking"),

--- a/man/with_nix.Rd
+++ b/man/with_nix.Rd
@@ -13,11 +13,12 @@ with_nix(
 )
 }
 \arguments{
-\item{expr}{Single R function or call, shell command, or list of them.}
+\item{expr}{Single R function or call, or character vector with shell command
+element optionally followed by command arguments (one flag per element).}
 
 \item{program}{String stating where to evaluate the expression. Either \code{"R"},
 the default, or \code{"shell"}. \code{where = "R"} will evaluate the expression via
-\code{RScript} and \code{where = "shell"} will run in \code{nix-shell}.}
+\code{RScript} and \code{where = "shell"} will run the system command in \code{nix-shell}.}
 
 \item{exec_mode}{Either \code{"blocking"} (default) or \verb{"non-blocking}. This
 will either block the R session while the \code{nix-build} shell command is
@@ -31,7 +32,18 @@ session.}
 either \code{"simple"} (default) or \code{"verbose"}, which shows the script that runs
 via \code{nix-shell}.}
 }
+\value{
+\itemize{
+\item if \code{program = "R"}, R object returned by function given in \code{expr}
+when evaluated via the R environment in \code{nix-shell} defined by Nix
+expression.
+\item if \code{program = "shell"}, character vector of standard output (stdout)
+of \code{expr} command sent to a command line interface provided by a Nix package.
+}
+}
 \description{
+This function needs an installation of Nix. \code{with_nix()} has two effects
+to run code in isolated and reproducible environments.
 \enumerate{
 \item Evaluate a function in R or a shell command via the \code{nix-shell}
 environment (Nix expression for custom software libraries; involving pinned
@@ -68,13 +80,28 @@ extra efforts such as setting up DevOps tooling like Docker and domain
 specific tools like {renv} to control complex software environments in R and
 any other language.
 
+\code{with_nix()} can evaluate both R code from a nix-R session within
+another nix-R session, and also from a host R session (i.e., on macOS or
+Linux) within a specific nix-R session. This feature is useful for testing
+the reproducibility and compatibility of given code across different software
+environments. If testing of different sets of environments is necessary, you
+can easily do so by providing Nix expressions in custom \code{.nix} or
+\code{default.nix} files in different subfolders of the project.
+
+This solution is very convenient because it gives direct feedback in
+read-eval-print-loop style, which gives a direct interface to the very
+reproducible infrastructure-as-code approach offered by Nix and Nixpkgs. You
+don't need extra efforts such as setting up DevOps tooling like Docker and
+domain specific tools like {renv} to control complex software environments in
+R and any other language.
+
 To do its job, \code{with_nix()} heavily relies on patterns that manipulate
-language expressions (aka computing on the language) offered in base R as well as
-the {codetools} package by Luke Tierney. Some of the key steps that are
-done behind the scene:
+language expressions (aka computing on the language) offered in base R as
+well as the {codetools} package by Luke Tierney. Some of the key steps that
+are done behind the scene:
 \enumerate{
-\item recursively find and export global objects (globals) in the call
-stack of \code{expr} as well as propagate R package environments found.
+\item recursively find, classify, and export global objects (globals) in the
+call stack of \code{expr} as well as propagate R package environments found.
 \item Serialize (save to disk) and deserialize (read from disk) dependent
 data structures as \code{.Rds} with necessary function arguments provided,
 any relevant globals in the call stack, packages, and \code{expr} outputs
@@ -83,5 +110,30 @@ returned in a temporary directory.
 reconstructed catching expressions with quoting; it is launched by commands
 like this via \code{{sys}} by Jeroen Ooms:
 \verb{nix-shell --pure --run "Rscript --vanilla"}.
+}
+}
+\examples{
+\dontrun{
+# create an isolated, runtime-pure R setup via Nix
+project_path <- "./sub_shell"
+init(
+  project_path = project_path,
+  rprofile_action = "create_missing"
+)
+# generate nix environment in `default.nix`
+rix(
+  r_ver = "4.2.0",
+  project_path = project_path
+)
+# evaluate function in Nix-R environment via `nix-shell` and `Rscript`,
+# stream messages, and bring output back to current R session
+out <- with_nix(
+  expr = function(mtcars) nrow(mtcars),
+  program = "R", exec_mode = "non-blocking", project_path = project_path,
+  message_type = "simple"
+)
+
+# There no limit in the complexity of function call stacks that `with_nix()`
+# can possibly handle
 }
 }

--- a/man/with_nix.Rd
+++ b/man/with_nix.Rd
@@ -32,5 +32,56 @@ either \code{"simple"} (default) or \code{"verbose"}, which shows the script tha
 via \code{nix-shell}.}
 }
 \description{
-Evaluate function in R or shell command via \code{nix-shell} environment
+\enumerate{
+\item Evaluate a function in R or a shell command via the \code{nix-shell}
+environment (Nix expression for custom software libraries; involving pinned
+versions of R and R packages via Nixpkgs)
+\item If no error, return the result object of \code{expr} in \code{with_nix()} into the
+current R session.
+}
+}
+\details{
+\code{with_nix()} gives you the power of evaluating a main function \code{expr}
+and its function call stack that are defined in the current R session
+in an encapsulated nix-R session defined by Nix expression (\code{default.nix}),
+which is located in at a distinct project path (\code{project_path}). It is for
+example useful for the following purposes.
+\enumerate{
+\item test compatibility of custom R code and software/package dependencies in
+development and production environments
+\item directly stream outputs (returned objects), messages and errors from any
+command line tool offered in Nixpkgs into an R session.
+\item Test if evolving R packages change their behavior for given unchanged
+R code, and whether they give identical results or not.
+}
+
+\code{with_nix()} can evaluate both R code from a nix-R session within
+another nix-R session, and also from a host R session (i.e., on macOS or
+Linux) within a specific nix-R  session. This feature is useful for testing
+the reproducibility and the compatibility of two and more sets (if repeatedly
+in isolated folders) of different software environments.
+
+This solution is very convenient because it gives direct feedback in
+read-eval-print-loop style, but from the very reproducible
+infrastructure-as-code approach offered by Nix and Nixpkgs. You don't need
+extra efforts such as setting up DevOps tooling like Docker and domain
+specific tools like {renv} to control complex software environments in R and
+any other language.
+
+To do its job, \code{with_nix()} heavily relies on patterns that manipulate
+language expressions (aka computing on the language) offered in base R as well as
+the {codetools} package by Luke Tierney. Some of the key steps that are
+done behind the scene:
+\enumerate{
+\item recursively find and export global objects (globals) in the call
+stack of \code{expr} as well as propagate R package environments found.
+\item Serialize (save to disk) and deserialize (read from disk) dependent
+data structures as \code{.Rds} with necessary function arguments provided,
+any relevant globals in the call stack, packages, and \code{expr} outputs
+returned in a temporary directory.
+\item Use pure \code{nix-shell} environments to execute a R code script
+reconstructed catching expressions with quoting; it is launched by commands
+like this via \code{{sys}} by Jeroen Ooms:
+\verb{nix-shell --pure --run "Rscript --vanilla"}.
+}
 }


### PR DESCRIPTION
- these two workhorses can now also run in RStudio on macOS.
- resolves #94 