### PR TITLE
`nix_build()` & `with_nix()`fix segmentation fault with adjusting `LD_LIBRARY_PATH` temporarily

### DIFF
--- a/R/with_nix.R
+++ b/R/with_nix.R
@@ -166,6 +166,32 @@ with_nix <- function(expr,
     set_nix_path()
   }
   
+  if (isTRUE(nzchar(Sys.getenv("NIX_STORE")))) {
+    # for Nix R sessions, guarantee that the system's user library 
+    # (R_LIBS_USER) is not in the search path for packages => run-time purity
+    current_libpaths <- .libPaths()
+    remove_r_libs_user()
+  } else {
+    LD_LIBRARY_PATH_default <- Sys.getenv("LD_LIBRARY_PATH")
+    if (nzchar(LD_LIBRARY_PATH_default)) {
+      # On some systems, like Ubuntu 22.04, we found that a preset 
+      # `LD_LIBRARY_PATH` environment variable in the system's R session
+      # (R installed via apt) is responsible for causing  a segmentation fault
+      # for both `nix-build` and `nix-shell` when invoked via 
+      # `sys::exec_internal`, `base::system()` or `base::system2()` from R.
+      # This seems due to incompatible linked libraries or permission issue that
+      # conflict when mixing Nix packages and libraries from the system.
+      # Therefore, we set it to `""` and set  back the default (old)
+      # `LD_LIBRARY_PATH` when `with_nix()` exits. For newer RStudio versions,
+      # LD_LIBRARY_PATH is not `""` anymore
+      # https://github.com/rstudio/rstudio/issues/12585
+      fix_ld_library_path()
+      cat("* Current LD_LIBRARY_PATH in system R session is:\n",
+        LD_LIBRARY_PATH_default)
+      cat("\n", "Setting `LD_LIBRARY_PATH` to `''` during `with_nix()`")
+    }
+  }
+  
   has_nix_shell <- nix_shell_available() # TRUE if yes, FALSE if no
   stopifnot("`nix-shell` not available. To install, we suggest you follow https://zero-to-nix.com/start/install ." =
     isTRUE(has_nix_shell))
@@ -312,6 +338,17 @@ with_nix <- function(expr,
   }
 
   cat("\n### Finished code evaluation in `nix-shell` ###\n")
+  
+  if (isTRUE(nzchar(Sys.getenv("NIX_STORE")))) {
+    # set back library paths to state before calling `with_nix()`
+     .libPaths(current_libpaths)
+  } else {
+    if (nzchar(LD_LIBRARY_PATH_default)) {
+      # set old LD_LIBRARY_PATH (only if system's R session and if it wasn't
+      # `""`)
+      on.exit(Sys.setenv(LD_LIBRARY_PATH=LD_LIBRARY_PATH_default))
+    }
+  }
   
   # return output from evaluated function
   cat("\n* Evaluating `expr` in `nix-shell` returns:\n")

--- a/dev/flat_nix_build.Rmd
+++ b/dev/flat_nix_build.Rmd
@@ -207,6 +207,11 @@ nix_build_exit_msg <- function(x) {
 
 testthat::test_that("Testing that `nix_build()` builds derivation", {
   
+  if (isFALSE(is_nix_rsession())) {
+    # needed for the GitHub test runners with system's R
+    set_nix_path()
+  }
+  
   skip_if_not(nix_shell_available())
   
   # skip_on_covr()

--- a/dev/flat_nix_build.Rmd
+++ b/dev/flat_nix_build.Rmd
@@ -42,7 +42,29 @@ nix_build <- function(project_path = ".",
   # if nix store is not PATH variable; e.g. on macOS (system's) RStudio
   PATH <- set_nix_path()
   if (isTRUE(nzchar(Sys.getenv("NIX_STORE")))) {
+    # for Nix R sessions, guarantee that the system's user library 
+    # (R_LIBS_USER) is not in the search path for packages => run-time purity
+    current_libpaths <- .libPaths()
     remove_r_libs_user()
+  } else {
+    LD_LIBRARY_PATH_default <- Sys.getenv("LD_LIBRARY_PATH")
+    if (nzchar(LD_LIBRARY_PATH_default)) {
+      # On some systems, like Ubuntu 22.04, we found that a preset 
+      # `LD_LIBRARY_PATH` environment variable in the system's R session
+      # (R installed via apt) is responsible for causing  a segmentation fault
+      # for both `nix-build` and `nix-shell` when invoked via 
+      # `sys::exec_internal`, `base::system()` or `base::system2()` from R.
+      # This seems due to incompatible linked libraries or permission issue that
+      # conflict when mixing Nix packages and libraries from the system.
+      # Therefore, we set it to `""` and set  back the default (old)
+      # `LD_LIBRARY_PATH` when `with_nix()` exits. For newer RStudio versions,
+      # LD_LIBRARY_PATH is not `""` anymore
+      # https://github.com/rstudio/rstudio/issues/12585
+      fix_ld_library_path()
+      cat("* Current LD_LIBRARY_PATH in system R session is:",
+        LD_LIBRARY_PATH_default)
+      cat("\n", "Setting `LD_LIBRARY_PATH` to `''` during `nix_build()`")
+    }
   }
   has_nix_build <- nix_build_installed() # TRUE if yes, FALSE if no
   nix_file <- normalizePath(file.path(project_path, "default.nix"))
@@ -86,7 +108,20 @@ nix_build <- function(project_path = ".",
   }
 
   # todo (?): clean zombies for background/non-blocking mode
-
+  
+  # set back library paths to state before calling `with_nix()`
+  
+  if (isTRUE(nzchar(Sys.getenv("NIX_STORE")))) {
+    # set back library paths to state before calling `with_nix()`
+    .libPaths(new = current_libpaths)
+  } else {
+    if (nzchar(LD_LIBRARY_PATH_default)) {
+       # set old LD_LIBRARY_PATH (only if system's R session and if it wasn't
+       # `""`)
+      on.exit(Sys.setenv(LD_LIBRARY_PATH=LD_LIBRARY_PATH_default))
+    }
+  }
+  
   return(invisible(proc))
 }
 
@@ -99,6 +134,13 @@ remove_r_libs_user <- function() {
   # sets new library path without user library, making nix-R pure at 
   # run-time
   invisible(.libPaths(new_paths))
+}
+
+#' @noRd
+fix_ld_library_path <- function() {
+  old_ld_library_path <- Sys.getenv("LD_LIBRARY_PATH")
+  Sys.setenv(LD_LIBRARY_PATH="")
+  invisible(old_ld_library_path)
 }
 
 #' @noRd

--- a/dev/flat_with_nix.Rmd
+++ b/dev/flat_with_nix.Rmd
@@ -175,6 +175,32 @@ with_nix <- function(expr,
     set_nix_path()
   }
   
+  if (isTRUE(nzchar(Sys.getenv("NIX_STORE")))) {
+    # for Nix R sessions, guarantee that the system's user library 
+    # (R_LIBS_USER) is not in the search path for packages => run-time purity
+    current_libpaths <- .libPaths()
+    remove_r_libs_user()
+  } else {
+    LD_LIBRARY_PATH_default <- Sys.getenv("LD_LIBRARY_PATH")
+    if (nzchar(LD_LIBRARY_PATH_default)) {
+      # On some systems, like Ubuntu 22.04, we found that a preset 
+      # `LD_LIBRARY_PATH` environment variable in the system's R session
+      # (R installed via apt) is responsible for causing  a segmentation fault
+      # for both `nix-build` and `nix-shell` when invoked via 
+      # `sys::exec_internal`, `base::system()` or `base::system2()` from R.
+      # This seems due to incompatible linked libraries or permission issue that
+      # conflict when mixing Nix packages and libraries from the system.
+      # Therefore, we set it to `""` and set  back the default (old)
+      # `LD_LIBRARY_PATH` when `with_nix()` exits. For newer RStudio versions,
+      # LD_LIBRARY_PATH is not `""` anymore
+      # https://github.com/rstudio/rstudio/issues/12585
+      fix_ld_library_path()
+      cat("* Current LD_LIBRARY_PATH in system R session is:\n",
+        LD_LIBRARY_PATH_default)
+      cat("\n", "Setting `LD_LIBRARY_PATH` to `''` during `with_nix()`")
+    }
+  }
+  
   has_nix_shell <- nix_shell_available() # TRUE if yes, FALSE if no
   stopifnot("`nix-shell` not available. To install, we suggest you follow https://zero-to-nix.com/start/install ." =
     isTRUE(has_nix_shell))
@@ -321,6 +347,17 @@ with_nix <- function(expr,
   }
 
   cat("\n### Finished code evaluation in `nix-shell` ###\n")
+  
+  if (isTRUE(nzchar(Sys.getenv("NIX_STORE")))) {
+    # set back library paths to state before calling `with_nix()`
+     .libPaths(current_libpaths)
+  } else {
+    if (nzchar(LD_LIBRARY_PATH_default)) {
+      # set old LD_LIBRARY_PATH (only if system's R session and if it wasn't
+      # `""`)
+      on.exit(Sys.setenv(LD_LIBRARY_PATH=LD_LIBRARY_PATH_default))
+    }
+  }
   
   # return output from evaluated function
   cat("\n* Evaluating `expr` in `nix-shell` returns:\n")

--- a/dev/flat_with_nix.Rmd
+++ b/dev/flat_with_nix.Rmd
@@ -876,6 +876,11 @@ create_shell_nix <- function(path = file.path("inst", "extdata",
 ```{r, tests-with_nix}
 testthat::test_that("Testing `with_nix()` if Nix is installed", {
 
+  if (isFALSE(is_nix_rsession())) {
+    # needed for the GitHub test runners with system's R
+    set_nix_path()
+  }
+  
   skip_if_not(nix_shell_available())
   # R version 3.5.3 on Nixpkgs does not build for aarch64-darwin (ARM macOS)
   skip_if(Sys.info()["sysname"] == "Darwin")
@@ -918,7 +923,12 @@ testthat::test_that("Testing `with_nix()` if Nix is installed", {
 })
 
 testthat::test_that("Test `with_nix()` if Nix is installed on R 4.2.0", {
-
+  
+  if (isFALSE(is_nix_rsession())) {
+    # needed for the GitHub test runners with system's R
+    set_nix_path()
+  }
+  
   skip_if_not(nix_shell_available())
 
   skip_on_covr()

--- a/tests/testthat/test-nix_build.R
+++ b/tests/testthat/test-nix_build.R
@@ -3,6 +3,11 @@
 
 testthat::test_that("Testing that `nix_build()` builds derivation", {
   
+  if (isFALSE(is_nix_rsession())) {
+    # needed for the GitHub test runners with system's R
+    set_nix_path()
+  }
+  
   skip_if_not(nix_shell_available())
   
   # skip_on_covr()

--- a/tests/testthat/test-with_nix.R
+++ b/tests/testthat/test-with_nix.R
@@ -2,6 +2,11 @@
 
 testthat::test_that("Testing `with_nix()` if Nix is installed", {
 
+  if (isFALSE(is_nix_rsession())) {
+    # needed for the GitHub test runners with system's R
+    set_nix_path()
+  }
+  
   skip_if_not(nix_shell_available())
   # R version 3.5.3 on Nixpkgs does not build for aarch64-darwin (ARM macOS)
   skip_if(Sys.info()["sysname"] == "Darwin")
@@ -44,7 +49,12 @@ testthat::test_that("Testing `with_nix()` if Nix is installed", {
 })
 
 testthat::test_that("Test `with_nix()` if Nix is installed on R 4.2.0", {
-
+  
+  if (isFALSE(is_nix_rsession())) {
+    # needed for the GitHub test runners with system's R
+    set_nix_path()
+  }
+  
   skip_if_not(nix_shell_available())
 
   skip_on_covr()


### PR DESCRIPTION
- Finally make `nix_build()` and `with_nix()` run on major Linux distros and also make `testthat::test()` pass