### PR TITLE
Do not remove `R_LIBS_USER` from .libPaths() in covr test environment

### DIFF
--- a/R/nix_build.R
+++ b/R/nix_build.R
@@ -32,7 +32,11 @@ nix_build <- function(project_path = ".",
     # for Nix R sessions, guarantee that the system's user library 
     # (R_LIBS_USER) is not in the search path for packages => run-time purity
     current_libpaths <- .libPaths()
-    remove_r_libs_user()
+    # don't do this in covr test environment, because this sets R_LIBS_USER
+    # to multiple paths
+    if (isFALSE(nzchar(Sys.getenv("R_COVR")))) {
+      remove_r_libs_user()
+    }
   } else {
     LD_LIBRARY_PATH_default <- Sys.getenv("LD_LIBRARY_PATH")
     if (nzchar(LD_LIBRARY_PATH_default)) {

--- a/R/nix_build.R
+++ b/R/nix_build.R
@@ -34,6 +34,7 @@ nix_build <- function(project_path = ".",
     current_libpaths <- .libPaths()
     # don't do this in covr test environment, because this sets R_LIBS_USER
     # to multiple paths
+    R_LIBS_USER <- Sys.getenv("R_LIBS_USER")
     if (isFALSE(nzchar(Sys.getenv("R_COVR")))) {
       remove_r_libs_user()
     }
@@ -118,13 +119,22 @@ nix_build <- function(project_path = ".",
 
 #' @noRd
 remove_r_libs_user <- function() {
-  current_paths <- .libPaths()
+  current_paths <- .libPaths() 
   userlib_paths <- Sys.getenv("R_LIBS_USER")
   user_dir <- grep(paste(userlib_paths, collapse = "|"), current_paths)
-  new_paths <- current_paths[-user_dir]
+  match <- length(user_dir) != 0L
+  if (isTRUE(match)) {
+    new_paths <- current_paths[-user_dir]
+  }
   # sets new library path without user library, making nix-R pure at 
   # run-time
-  invisible(.libPaths(new_paths))
+  invisible({
+    if (isTRUE(match)) {
+      .libPaths(new_paths)
+    } else {
+      .libPaths()
+    }
+  })
 }
 
 #' @noRd

--- a/R/with_nix.R
+++ b/R/with_nix.R
@@ -170,7 +170,12 @@ with_nix <- function(expr,
     # for Nix R sessions, guarantee that the system's user library 
     # (R_LIBS_USER) is not in the search path for packages => run-time purity
     current_libpaths <- .libPaths()
-    remove_r_libs_user()
+    # don't do this in covr test environment, because this sets R_LIBS_USER
+    # to multiple paths
+    R_LIBS_USER <- Sys.getenv("R_LIBS_USER")
+    if (isFALSE(nzchar(Sys.getenv("R_COVR")))) {
+      remove_r_libs_user()
+    }
   } else {
     LD_LIBRARY_PATH_default <- Sys.getenv("LD_LIBRARY_PATH")
     if (nzchar(LD_LIBRARY_PATH_default)) {
@@ -186,9 +191,9 @@ with_nix <- function(expr,
       # LD_LIBRARY_PATH is not `""` anymore
       # https://github.com/rstudio/rstudio/issues/12585
       fix_ld_library_path()
-      cat("* Current LD_LIBRARY_PATH in system R session is:\n",
+      cat("* Current LD_LIBRARY_PATH in system R session is:",
         LD_LIBRARY_PATH_default)
-      cat("\n", "Setting `LD_LIBRARY_PATH` to `''` during `with_nix()`")
+      cat("\n", "Setting `LD_LIBRARY_PATH` to `''` during `nix_build()`")
     }
   }
   

--- a/dev/flat_nix_build.Rmd
+++ b/dev/flat_nix_build.Rmd
@@ -47,6 +47,7 @@ nix_build <- function(project_path = ".",
     current_libpaths <- .libPaths()
     # don't do this in covr test environment, because this sets R_LIBS_USER
     # to multiple paths
+    R_LIBS_USER <- Sys.getenv("R_LIBS_USER")
     if (isFALSE(nzchar(Sys.getenv("R_COVR")))) {
       remove_r_libs_user()
     }
@@ -131,13 +132,22 @@ nix_build <- function(project_path = ".",
 
 #' @noRd
 remove_r_libs_user <- function() {
-  current_paths <- .libPaths()
+  current_paths <- .libPaths() 
   userlib_paths <- Sys.getenv("R_LIBS_USER")
   user_dir <- grep(paste(userlib_paths, collapse = "|"), current_paths)
-  new_paths <- current_paths[-user_dir]
+  match <- length(user_dir) != 0L
+  if (isTRUE(match)) {
+    new_paths <- current_paths[-user_dir]
+  }
   # sets new library path without user library, making nix-R pure at 
   # run-time
-  invisible(.libPaths(new_paths))
+  invisible({
+    if (isTRUE(match)) {
+      .libPaths(new_paths)
+    } else {
+      .libPaths()
+    }
+  })
 }
 
 #' @noRd

--- a/dev/flat_nix_build.Rmd
+++ b/dev/flat_nix_build.Rmd
@@ -45,7 +45,11 @@ nix_build <- function(project_path = ".",
     # for Nix R sessions, guarantee that the system's user library 
     # (R_LIBS_USER) is not in the search path for packages => run-time purity
     current_libpaths <- .libPaths()
-    remove_r_libs_user()
+    # don't do this in covr test environment, because this sets R_LIBS_USER
+    # to multiple paths
+    if (isFALSE(nzchar(Sys.getenv("R_COVR")))) {
+      remove_r_libs_user()
+    }
   } else {
     LD_LIBRARY_PATH_default <- Sys.getenv("LD_LIBRARY_PATH")
     if (nzchar(LD_LIBRARY_PATH_default)) {

--- a/dev/flat_with_nix.Rmd
+++ b/dev/flat_with_nix.Rmd
@@ -179,7 +179,12 @@ with_nix <- function(expr,
     # for Nix R sessions, guarantee that the system's user library 
     # (R_LIBS_USER) is not in the search path for packages => run-time purity
     current_libpaths <- .libPaths()
-    remove_r_libs_user()
+    # don't do this in covr test environment, because this sets R_LIBS_USER
+    # to multiple paths
+    R_LIBS_USER <- Sys.getenv("R_LIBS_USER")
+    if (isFALSE(nzchar(Sys.getenv("R_COVR")))) {
+      remove_r_libs_user()
+    }
   } else {
     LD_LIBRARY_PATH_default <- Sys.getenv("LD_LIBRARY_PATH")
     if (nzchar(LD_LIBRARY_PATH_default)) {
@@ -195,9 +200,9 @@ with_nix <- function(expr,
       # LD_LIBRARY_PATH is not `""` anymore
       # https://github.com/rstudio/rstudio/issues/12585
       fix_ld_library_path()
-      cat("* Current LD_LIBRARY_PATH in system R session is:\n",
+      cat("* Current LD_LIBRARY_PATH in system R session is:",
         LD_LIBRARY_PATH_default)
-      cat("\n", "Setting `LD_LIBRARY_PATH` to `''` during `with_nix()`")
+      cat("\n", "Setting `LD_LIBRARY_PATH` to `''` during `nix_build()`")
     }
   }
   


### PR DESCRIPTION
- Relevant when running `covr::package_coverage()` in Nix-R session (covr sets multiple lib paths for `R_LIBS_USER`