### PR TITLE
Add note on `aarch64-darwin` backwards compatibility for Nixpkgs R

### DIFF
--- a/dev/b2-macos.Rmd
+++ b/dev/b2-macos.Rmd
@@ -18,7 +18,7 @@ When it comes to Nix, there are really only two supported operating systems:
 macOS and Linux distributions. Windows is "supported" because it is actually
 running Linux thanks to WSL2. In practice this means that Linux distributions
 and Windows can be considered one system, and macOS another, separate, system,
-with its own idiosyncracies. This vignette details these.
+with its own idiosyncrasies. This vignette details these.
 
 ## Installing Nix
 
@@ -99,7 +99,7 @@ to learn more.
 In Nixpkgs, the M series processors of the ARM64 family, also known under
 AArch64, supports R since R version 3.5.3. Earlier versions of R will not 
 compile on modern Apple processor architectures for the correspoding Nixpkgs
-revisions at that time. Hence, the `darwin-aarch64` architecture has constrained
+revisions at that time. Hence, the `darwin-aarch64` platform has constrained
 backwards-compatibility.
 
 ### Shared libraries issue

--- a/dev/b2-macos.Rmd
+++ b/dev/b2-macos.Rmd
@@ -94,6 +94,14 @@ to learn more.
 
 ## More macOS specificities
 
+### R Support for Apple Silicon in Nixpkgs
+
+In Nixpkgs, the M series processors of the ARM64 family, also known under
+AArch64, supports R since R version 3.5.3. Earlier versions of R will not 
+compile on modern Apple processor architectures for the correspoding Nixpkgs
+revisions at that time. Hence, the `darwin-aarch64` architecture has constrained
+backwards-compatibility.
+
 ### Shared libraries issue
 
 When using environments built with Nix on macOS, you might get crashes 

--- a/dev/b2-macos.Rmd
+++ b/dev/b2-macos.Rmd
@@ -98,7 +98,7 @@ to learn more.
 
 In Nixpkgs, the M series processors of the ARM64 family, also known under
 AArch64, supports R since R version 3.5.3. Earlier versions of R will not 
-compile on modern Apple processor architectures for the correspoding Nixpkgs
+compile on modern Apple processor architectures for the corresponding Nixpkgs
 revisions at that time. Hence, the `darwin-aarch64` platform has constrained
 backwards-compatibility.
 

--- a/vignettes/b2-setting-up-and-using-rix-on-macos.Rmd
+++ b/vignettes/b2-setting-up-and-using-rix-on-macos.Rmd
@@ -32,7 +32,7 @@ When it comes to Nix, there are really only two supported operating systems:
 macOS and Linux distributions. Windows is "supported" because it is actually
 running Linux thanks to WSL2. In practice this means that Linux distributions
 and Windows can be considered one system, and macOS another, separate, system,
-with its own idiosyncracies. This vignette details these.
+with its own idiosyncrasies. This vignette details these.
 
 
 ## Installing Nix
@@ -118,7 +118,7 @@ to learn more.
 In Nixpkgs, the M series processors of the ARM64 family, also known under
 AArch64, supports R since R version 3.5.3. Earlier versions of R will not 
 compile on modern Apple processor architectures for the correspoding Nixpkgs
-revisions at that time. Hence, the `darwin-aarch64` architecture has constrained
+revisions at that time. Hence, the `darwin-aarch64` platform has constrained
 backwards-compatibility.
 
 

--- a/vignettes/b2-setting-up-and-using-rix-on-macos.Rmd
+++ b/vignettes/b2-setting-up-and-using-rix-on-macos.Rmd
@@ -117,7 +117,7 @@ to learn more.
 
 In Nixpkgs, the M series processors of the ARM64 family, also known under
 AArch64, supports R since R version 3.5.3. Earlier versions of R will not 
-compile on modern Apple processor architectures for the correspoding Nixpkgs
+compile on modern Apple processor architectures for the corresponding Nixpkgs
 revisions at that time. Hence, the `darwin-aarch64` platform has constrained
 backwards-compatibility.
 

--- a/vignettes/b2-setting-up-and-using-rix-on-macos.Rmd
+++ b/vignettes/b2-setting-up-and-using-rix-on-macos.Rmd
@@ -46,7 +46,7 @@ a company that provides services and tools built on Nix. Simply open a terminal
 and run the following line:
 
 
-```{sh eval = FALSE}
+```{sh, eval = FALSE}
 curl --proto '=https' --tlsv1.2 -sSf \
     -L https://install.determinate.systems/nix | \
      sh -s -- install
@@ -101,7 +101,7 @@ R session, and install `{rix}` if that's not already done. Because `{rix}` is
 not yet on CRAN, the easiest way is to install it from its r-universe:
 
 
-```{r eval = FALSE}
+```{r, eval = FALSE}
 install.packages("rix", repos = c("https://b-rodrigues.r-universe.dev",
   "https://cloud.r-project.org"))
 ```
@@ -112,6 +112,15 @@ to learn more.
 
 
 ## More macOS specificities
+
+### R Support for Apple Silicon in Nixpkgs
+
+In Nixpkgs, the M series processors of the ARM64 family, also known under
+AArch64, supports R since R version 3.5.3. Earlier versions of R will not 
+compile on modern Apple processor architectures for the correspoding Nixpkgs
+revisions at that time. Hence, the `darwin-aarch64` architecture has constrained
+backwards-compatibility.
+
 
 ### Shared libraries issue
 


### PR DESCRIPTION
addresses #117