### PR TITLE
Add more IDE-s: rserver and radian

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,6 +21,7 @@ Imports:
     sys,
     utils
 Suggests: 
+    curl,
     knitr,
     rmarkdown,
     testthat

--- a/R/rix.R
+++ b/R/rix.R
@@ -16,19 +16,20 @@
 #' @param git_pkgs List. A list of packages to install from Git. See details for more information.
 #' @param tex_pkgs Vector of characters. A set of tex packages to install. Use this if you need to compile `.tex` documents, or build PDF documents using Quarto. If you don't know which package to add, start by adding "amsmath". See the Vignette "Authoring LaTeX documents" for more details.
 #' @param ide Character, defaults to "other". If you wish to use RStudio to work
-#'   interactively use "rstudio" or "code" for Visual Studio Code. For other editors,
-#'   use "other". This has been tested with RStudio, VS Code and Emacs. If other
-#'   editors don't work, please open an issue.
-#' @param project_path Character, defaults to the current working directory. 
+#'   interactively use "rstudio" or "rserver" for the server version. Use "code"
+#    for Visual Studio Code. You can also use "radian", an interactive REPL. For
+#'   other editors, use "other". This has been tested with RStudio, VS Code and
+#'   Emacs. If other editors don't work, please open an issue.
+#' @param project_path Character, defaults to the current working directory.
 #'   Where to write `default.nix`, for example "/home/path/to/project".
-#'   The file will thus be written to the file 
+#'   The file will thus be written to the file
 #'   "/home/path/to/project/default.nix".
 #' @param overwrite Logical, defaults to FALSE. If TRUE, overwrite the `default.nix`
 #'   file in the specified path.
 #' @param print Logical, defaults to FALSE. If TRUE, print `default.nix` to console.
 #' @param shell_hook Character of length 1, defaults to `NULL`. Commands added
 #'   to the `shellHook` variable executed when the Nix shell starts. So
-#'   by default, using `nix-shell default.nix` (or path with `shell.nix`) will 
+#'   by default, using `nix-shell default.nix` (or path with `shell.nix`) will
 #'   start a specific program, possibly with flags (separated by space), and/or
 #'   do shell actions. You can for example use `shell_hook = R`, if you want to
 #'   directly enter the declared Nix R session.
@@ -64,7 +65,7 @@
 #'   `LC_PAPER`, `LC_MEASUREMENT`). This is done to ensure locale
 #'   reproducibility by default in Nix environments created with `rix()`.
 #'   If there are good reasons to not stick to the default, you can set your
-#'   preferred locale variables via 
+#'   preferred locale variables via
 #'   `options(rix.nix_locale_variables = list(LANG = "de_CH.UTF-8", <...>)`
 #'   and the aforementioned locale variable names.
 #' @export
@@ -87,13 +88,20 @@ rix <- function(r_ver = "latest",
                 system_pkgs = NULL,
                 git_pkgs = NULL,
                 tex_pkgs = NULL,
-                ide = "other",
+                ide = c("other", "code", "radian", "rstudio", "rserver"),
                 project_path = ".",
                 overwrite = FALSE,
                 print = FALSE,
                 shell_hook = NULL){
 
-  stopifnot("'ide' has to be one of 'other', 'rstudio' or 'code'" = (ide %in% c("other", "rstudio", "code")))
+  ide <- match.arg(ide, c("other", "code", "radian", "rstudio", "rserver"))
+
+  # Wrapper attributes to be used later
+  attrib = c(
+    radian = "radianWrapper",
+    rstudio = "rstudioWrapper",
+    rserver = "rstudioServerWrapper"
+  )
 
   if(Sys.info()["sysname"] == "Darwin" & ide == "rstudio"){
     warning(
@@ -316,14 +324,15 @@ get_system_pkgs(system_pkgs, r_pkgs))
     paste0(locale_vars, ";\n")
   }
 
-  generate_rstudio_pkgs <- function(ide, flag_git_archive, flag_rpkgs){
+  generate_wrapped_pkgs <- function(ide, attrib, flag_git_archive, flag_rpkgs){
     if (flag_rpkgs == ""){
       return(NULL)
-      } else if(ide == "rstudio"){
-      sprintf('rstudio_pkgs = pkgs.rstudioWrapper.override {
+      } else if(ide %in% names(attrib)){
+      sprintf('wrapped_pkgs = pkgs.%s.override {
   packages = [ %s %s ];
 };
 ',
+attrib[ide],
 flag_git_archive,
 flag_rpkgs
 )
@@ -332,7 +341,7 @@ flag_rpkgs
     }
   }
 
-  flag_rstudio <- if (ide == "rstudio" & flag_rpkgs != "") "rstudio_pkgs" else ""
+  flag_wrapper <- if (ide %in% names(attrib) & flag_rpkgs != "") "wrapped_pkgs" else ""
 
   shell_hook <- if (!is.null(shell_hook) && nzchar(shell_hook)) {
     paste0('shellHook = "', shell_hook, '";')
@@ -353,7 +362,7 @@ flag_rpkgs
   flag_git_archive,
   flag_rpkgs,
   flag_tex_pkgs,
-  flag_rstudio,
+  flag_wrapper,
   shell_hook
   )
 
@@ -369,7 +378,7 @@ flag_rpkgs
     generate_git_archived_packages(git_pkgs, cran_pkgs$archive_pkgs),
     generate_tex_pkgs(tex_pkgs),
     generate_system_pkgs(system_pkgs, r_pkgs),
-    generate_rstudio_pkgs(ide, flag_git_archive, flag_rpkgs),
+    generate_wrapped_pkgs(ide, attrib, flag_git_archive, flag_rpkgs),
     generate_shell(flag_git_archive, flag_rpkgs),
     collapse = "\n"
     )

--- a/dev/flat_rix.Rmd
+++ b/dev/flat_rix.Rmd
@@ -1,4 +1,4 @@
----
+--
 title: "rix"
 output: html_document
 editor_options:
@@ -32,19 +32,20 @@ you use another IDE, you can leave the "ide" argument blank:
 #' @param git_pkgs List. A list of packages to install from Git. See details for more information.
 #' @param tex_pkgs Vector of characters. A set of tex packages to install. Use this if you need to compile `.tex` documents, or build PDF documents using Quarto. If you don't know which package to add, start by adding "amsmath". See the Vignette "Authoring LaTeX documents" for more details.
 #' @param ide Character, defaults to "other". If you wish to use RStudio to work
-#'   interactively use "rstudio" or "code" for Visual Studio Code. For other editors,
-#'   use "other". This has been tested with RStudio, VS Code and Emacs. If other
-#'   editors don't work, please open an issue.
-#' @param project_path Character, defaults to the current working directory. 
+#'   interactively use "rstudio" or "rserver" for the server version. Use "code"
+#    for Visual Studio Code. You can also use "radian", an interactive REPL. For
+#'   other editors, use "other". This has been tested with RStudio, VS Code and
+#'   Emacs. If other editors don't work, please open an issue.
+#' @param project_path Character, defaults to the current working directory.
 #'   Where to write `default.nix`, for example "/home/path/to/project".
-#'   The file will thus be written to the file 
+#'   The file will thus be written to the file
 #'   "/home/path/to/project/default.nix".
 #' @param overwrite Logical, defaults to FALSE. If TRUE, overwrite the `default.nix`
 #'   file in the specified path.
 #' @param print Logical, defaults to FALSE. If TRUE, print `default.nix` to console.
 #' @param shell_hook Character of length 1, defaults to `NULL`. Commands added
 #'   to the `shellHook` variable executed when the Nix shell starts. So
-#'   by default, using `nix-shell default.nix` (or path with `shell.nix`) will 
+#'   by default, using `nix-shell default.nix` (or path with `shell.nix`) will
 #'   start a specific program, possibly with flags (separated by space), and/or
 #'   do shell actions. You can for example use `shell_hook = R`, if you want to
 #'   directly enter the declared Nix R session.
@@ -80,7 +81,7 @@ you use another IDE, you can leave the "ide" argument blank:
 #'   `LC_PAPER`, `LC_MEASUREMENT`). This is done to ensure locale
 #'   reproducibility by default in Nix environments created with `rix()`.
 #'   If there are good reasons to not stick to the default, you can set your
-#'   preferred locale variables via 
+#'   preferred locale variables via
 #'   `options(rix.nix_locale_variables = list(LANG = "de_CH.UTF-8", <...>)`
 #'   and the aforementioned locale variable names.
 #' @export
@@ -103,13 +104,20 @@ rix <- function(r_ver = "latest",
                 system_pkgs = NULL,
                 git_pkgs = NULL,
                 tex_pkgs = NULL,
-                ide = "other",
+                ide = c("other", "code", "radian", "rstudio", "rserver"),
                 project_path = ".",
                 overwrite = FALSE,
                 print = FALSE,
                 shell_hook = NULL){
 
-  stopifnot("'ide' has to be one of 'other', 'rstudio' or 'code'" = (ide %in% c("other", "rstudio", "code")))
+  ide <- match.arg(ide, c("other", "code", "radian", "rstudio", "rserver"))
+
+  # Wrapper attributes to be used later
+  attrib = c(
+    radian = "radianWrapper",
+    rstudio = "rstudioWrapper",
+    rserver = "rstudioServerWrapper"
+  )
 
   if(Sys.info()["sysname"] == "Darwin" & ide == "rstudio"){
     warning(
@@ -332,14 +340,15 @@ get_system_pkgs(system_pkgs, r_pkgs))
     paste0(locale_vars, ";\n")
   }
 
-  generate_rstudio_pkgs <- function(ide, flag_git_archive, flag_rpkgs){
+  generate_wrapped_pkgs <- function(ide, attrib, flag_git_archive, flag_rpkgs){
     if (flag_rpkgs == ""){
       return(NULL)
-      } else if(ide == "rstudio"){
-      sprintf('rstudio_pkgs = pkgs.rstudioWrapper.override {
+      } else if(ide %in% names(attrib)){
+      sprintf('wrapped_pkgs = pkgs.%s.override {
   packages = [ %s %s ];
 };
 ',
+attrib[ide],
 flag_git_archive,
 flag_rpkgs
 )
@@ -348,7 +357,7 @@ flag_rpkgs
     }
   }
 
-  flag_rstudio <- if (ide == "rstudio" & flag_rpkgs != "") "rstudio_pkgs" else ""
+  flag_wrapper <- if (ide %in% names(attrib) & flag_rpkgs != "") "wrapped_pkgs" else ""
 
   shell_hook <- if (!is.null(shell_hook) && nzchar(shell_hook)) {
     paste0('shellHook = "', shell_hook, '";')
@@ -369,7 +378,7 @@ flag_rpkgs
   flag_git_archive,
   flag_rpkgs,
   flag_tex_pkgs,
-  flag_rstudio,
+  flag_wrapper,
   shell_hook
   )
 
@@ -385,7 +394,7 @@ flag_rpkgs
     generate_git_archived_packages(git_pkgs, cran_pkgs$archive_pkgs),
     generate_tex_pkgs(tex_pkgs),
     generate_system_pkgs(system_pkgs, r_pkgs),
-    generate_rstudio_pkgs(ide, flag_git_archive, flag_rpkgs),
+    generate_wrapped_pkgs(ide, attrib, flag_git_archive, flag_rpkgs),
     generate_shell(flag_git_archive, flag_rpkgs),
     collapse = "\n"
     )

--- a/man/rix.Rd
+++ b/man/rix.Rd
@@ -10,7 +10,7 @@ rix(
   system_pkgs = NULL,
   git_pkgs = NULL,
   tex_pkgs = NULL,
-  ide = "other",
+  ide = c("other", "code", "radian", "rstudio", "rserver"),
   project_path = ".",
   overwrite = FALSE,
   print = FALSE,
@@ -34,9 +34,9 @@ available software on the NixOS website \url{https://search.nixos.org/packages?c
 \item{tex_pkgs}{Vector of characters. A set of tex packages to install. Use this if you need to compile \code{.tex} documents, or build PDF documents using Quarto. If you don't know which package to add, start by adding "amsmath". See the Vignette "Authoring LaTeX documents" for more details.}
 
 \item{ide}{Character, defaults to "other". If you wish to use RStudio to work
-interactively use "rstudio" or "code" for Visual Studio Code. For other editors,
-use "other". This has been tested with RStudio, VS Code and Emacs. If other
-editors don't work, please open an issue.}
+interactively use "rstudio" or "rserver" for the server version. Use "code"
+other editors, use "other". This has been tested with RStudio, VS Code and
+Emacs. If other editors don't work, please open an issue.}
 
 \item{project_path}{Character, defaults to the current working directory.
 Where to write \code{default.nix}, for example "/home/path/to/project".

--- a/tests/testthat/_snaps/rix/rstudio_default.nix
+++ b/tests/testthat/_snaps/rix/rstudio_default.nix
@@ -43,7 +43,7 @@ let
  system_packages = builtins.attrValues {
   inherit (pkgs) R glibcLocales nix quarto;
 };
- rstudio_pkgs = pkgs.rstudioWrapper.override {
+ wrapped_pkgs = pkgs.rstudioWrapper.override {
   packages = [ git_archive_pkgs rpkgs ];
 };
  in
@@ -56,6 +56,6 @@ let
     LC_PAPER = "en_US.UTF-8";
     LC_MEASUREMENT = "en_US.UTF-8";
 
-    buildInputs = [ git_archive_pkgs rpkgs tex system_packages rstudio_pkgs ];
+    buildInputs = [ git_archive_pkgs rpkgs tex system_packages wrapped_pkgs ];
       
   }

--- a/vignettes/b1-setting-up-and-using-rix-on-linux-and-windows.Rmd
+++ b/vignettes/b1-setting-up-and-using-rix-on-linux-and-windows.Rmd
@@ -36,8 +36,12 @@ Because Windows is really running Linux under the hood thanks to WSL2, this
 means that WSL2 needs to be running on your Windows system before you attempt to
 install Nix. But it is important to know that you can run `{rix}` even if you
 don't have Nix installed, which means you can generate Nix expressions, you
-just can't build them.
+just can't build them. So if you can’t install Nix on your system, but have 
+R already installed, you can skip to the last section of this vignette to 
+simply install the `{rix}` package.
 
+
+## Installing Nix
 
 ### Windows pre-requisites
 
@@ -80,7 +84,7 @@ Afterwards, you can install Nix like business as usual. You can proceed with the
 Determinate Systems installer.
 
 
-## Installing Nix
+### The Determinate Systems installer
 
 You can use `{rix}` to generate Nix expressions even if you don't have Nix
 installed on your system, but obviously, you need to install Nix if you actually
@@ -119,7 +123,7 @@ If you have enough space on your root partition, you can ignore the above
 instructions.
 
 
-## What if you don't have R already installed?
+## Case 1: you don’t have R installed and wish to install it using Nix as well
 
 If you have successfully installed Nix, but don't have yet R installed on your
 system, you could install R as you would usually do on your operating system,
@@ -147,18 +151,37 @@ rix(r_ver = "latest",
 
 to generate a `default.nix`, and then use that file to generate an environment
 with R, `{dplyr}` and `{ggplot2}`. If you need to add packages for your project,
-rerun the command above, but add the needed packages to `r_pkgs`. This is
-detailled in the vignette `vignette("d1-installing-r-packages-in-a-nix-environment")` and
+rerun the command above, but add the needed packages to `r_pkgs`. Beware that if
+your already have a `default.nix` file in the working directory, running
+`rix()` with the `overwrite = TRUE` argument will overwrite it! So make sure
+that you are using a version control system for your projects to avoid bad surprises.
+
+More details about managing project-specific `default.nix` are detailled in the 
+vignette `vignette("d1-installing-r-packages-in-a-nix-environment")` and
 `vignette("d2-installing-system-tools-and-texlive-packages-in-a-nix-environment")`.
 
+You could also include `{rix}` in your project-specific environments, by generating
+a `default.nix` like so:
 
-## Generating expressions
+```
+rix(r_ver = "latest",
+    r_pkgs = NULL,
+    git_pkgs = list(package_name = "rix",
+                   repo_url = "https://github.com/b-rodrigues/rix",
+                   branch_name = "master",
+                   commit = "76d1bdd03d78589d399b4b9d473ecde616920a82"),
+    ide = "other",
+    project_path = ".",
+    overwrite = TRUE)
+```
 
-Once you have R installed, either through the usual installer for your operating
-system, or through Nix as explained previously, you can now start building
-project-specific development environments.
+Change the commit to a more recent one and adapt the `project_path` argument if needed.
 
-Start an R session, and install `{rix}` if that's not already done. Because
+
+## Case 2: you have R installed through your OS’s package manager
+
+If you have installed R on your system through the usual means of installation (so not Nix,
+as decribed before), you can install the `{rix}` package as usual as well. Because
 `{rix}` is not yet on CRAN, the easiest way is to install it from its
 r-universe:
 


### PR DESCRIPTION
Adds support to RStudio server and radian. It is done in a way that avoids core repetition, and allows easy addition of future wrappers.

In addition, {fusen} also modified some files (vignetters, DESCRIPTION), probably for the better, so I also included those in the commit.