### PR TITLE
`rix_init()` implement "quiet" and improve "simple" message_type

### DIFF
--- a/R/rix_init.R
+++ b/R/rix_init.R
@@ -198,7 +198,7 @@ rix_init <- function(project_path = ".",
   )
       
   if (message_type == "verbose") {
-    cat("\n* Current lines of local `.Rprofile` are:\n\n")
+    cat("\n\n* Current lines of local `.Rprofile` are:\n\n")
     cat(readLines(con = file(rprofile_file)), sep = "\n")
   }
   

--- a/R/rix_init.R
+++ b/R/rix_init.R
@@ -66,7 +66,9 @@
 #' project setup.
 #' @param message_type Character. Message type, defaults to `"simple"`, which 
 #' gives minimal but sufficient feedback. Other values are currently 
-#' `"verbose"`, which provides more detailed diagnostics.
+#' `"quiet`, which writes `.Rprofile` without message, and
+#' `"verbose"`, which provides the actions done to achieve fully controlled 
+#' R project environments in Nix.
 #' @export
 #' @seealso [with_nix()]
 #' @return Nothing, this function only has the side-effect of writing a file

--- a/man/rix_init.Rd
+++ b/man/rix_init.Rd
@@ -29,7 +29,9 @@ project setup.}
 
 \item{message_type}{Character. Message type, defaults to \code{"simple"}, which
 gives minimal but sufficient feedback. Other values are currently
-\code{"verbose"}, which provides more detailed diagnostics.}
+\verb{"quiet}, which writes \code{.Rprofile} without message, and
+\code{"verbose"}, which provides the actions done to achieve fully controlled
+R project environments in Nix.}
 }
 \value{
 Nothing, this function only has the side-effect of writing a file

--- a/man/rix_init.Rd
+++ b/man/rix_init.Rd
@@ -8,7 +8,7 @@ setup via Nix.}
 rix_init(
   project_path = ".",
   rprofile_action = c("create_missing", "create_backup", "overwrite", "append"),
-  message_type = c("simple", "verbose")
+  message_type = c("simple", "quiet", "verbose")
 )
 }
 \arguments{
@@ -91,9 +91,11 @@ code ran between two software environments with \code{rix::with_nix()}.
 \dontrun{
 # create an isolated, runtime-pure R setup via Nix
 project_path <- "./sub_shell"
+if (!dir.exist(project_path)) dir.create(project_path)
 rix_init(
   project_path = project_path,
-  rprofile_action = "create_missing"
+  rprofile_action = "create_missing",
+  message_type = c("simple")
 )
 }
 }


### PR DESCRIPTION
There is a new `message_type = "quiet"` option which writes rix init `.Rprofile` without any message to the user. 
Also, `message_type = "simple"` is a bit slimmer.

*Simple* (default)

```{r}
> rix_init(message_type = "simple")

### Bootstrapping isolated, project-specific, and runtime-pure R setup via Nix ###

==> Existing isolated nix-R project folder:
 /Users/philipp/git/philipp-baumann-shared/rix 

==> R session running via host operating system or docker

* Keep existing `.Rprofile`. in `project_path`:
 /Users/philipp/git/philipp-baumann-shared/rix/ 


==> Also adjusting `PATH` via `Sys.setenv()`, so that system commands can invoke key Nix commands like `nix-build` in this RStudio session on the host operating system.
```

*Quiet*: as expected, doesn't message

```{r}
> rix_init(message_type = "quiet")
```

*Verbose*: output messages help to understand the working principles verbosely:

```{r}
> rix_init(message_type = "verbose")

### Bootstrapping isolated, project-specific, and runtime-pure R setup via Nix ###

==> Existing isolated nix-R project folder:
 /Users/philipp/git/philipp-baumann-shared/rix 

==> R session running from RStudio

* Keep existing `.Rprofile`. in `project_path`:
 /Users/philipp/git/philipp-baumann-shared/rix/ 


* Current `PATH` variable set in R session is:

/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Applications/quarto/bin:/Library/TeX/texbin:/usr/texbin:/nix/var/nix/profiles/default/bin:/Applications/RStudio.app/Contents/Resources/app/bin/postback

==> Also adjusting `PATH` via `Sys.setenv()`, so that system commands can invoke key Nix commands like `nix-build` in this RStudio session on the host operating system.

* Updated `PATH` variable is:

 /usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Applications/quarto/bin:/Library/TeX/texbin:/usr/texbin:/nix/var/nix/profiles/default/bin:/Applications/RStudio.app/Contents/Resources/app/bin/postback

* Current lines of local `.Rprofile` are:

### File generated by `rix::rix_init()` ###
# 1. Currently, system RStudio does not inherit environmental variables
#   defined in `$HOME/.zshrc`, `$HOME/.bashrc` and alike. This is workaround to 
#   make the path of the nix store and hence basic nix commands available
#   in an RStudio session
# 2. For nix-R session, remove `R_LIBS_USER`, system's R user library.`.
#   This guarantees no user libraries from the system are loaded and only 
#   R packages in the Nix store are used. This makes Nix-R behave in pure manner
#   at run-time.
{
    is_rstudio <- Sys.getenv("RSTUDIO") == "1"
    is_nixr <- nzchar(Sys.getenv("NIX_STORE"))
    if (isFALSE(is_nixr) && isTRUE(is_rstudio)) {
        cat("{rix} detected RStudio R session")
        old_path <- Sys.getenv("PATH")
        nix_path <- "/nix/var/nix/profiles/default/bin"
        has_nix_path <- any(grepl(nix_path, old_path))
        if (isFALSE(has_nix_path)) {
            Sys.setenv(PATH = paste(old_path, nix_path, sep = ":"))
        }
        rm(old_path, nix_path)
    }
    if (isTRUE(is_nixr)) {
        current_paths <- .libPaths()
        userlib_paths <- Sys.getenv("R_LIBS_USER")
        user_dir <- grep(paste(userlib_paths, collapse = "|"), current_paths)
        new_paths <- current_paths[-user_dir]
        .libPaths(new_paths)
        rm(current_paths, userlib_paths, user_dir, new_paths)
    }
    rm(is_rstudio, is_nixr)
}
```