### PR TITLE
warn users that generate an expression for an old version of R

### DIFF
--- a/R/rix.R
+++ b/R/rix.R
@@ -142,6 +142,12 @@ before continuing."
     )
   }
 
+  if(r_ver %in% available_r() & r_ver != "latest" & r_ver <= "4.1.1"){
+    warning(
+      "You are generating an expression for an older version of R.\n To use this environment, you should directly use `nix-shell` and not try to build it first using `nix-build`."
+    )
+  }
+
   if(r_ver == "4.4.0"){
     warning(
       "You chose '4.4.0' as the R version, however this version is not available in nixpkgs. The generated expression will thus install R version 4.4.1."

--- a/tests/testthat/test-rix.R
+++ b/tests/testthat/test-rix.R
@@ -234,6 +234,31 @@ testthat::test_that("If R version is <= 4.1.1, raise warning", {
 
 })
 
+testthat::test_that("If R version is == 3.5.3, raise warning", {
+
+  path_default_nix <- tempdir()
+
+  save_default_nix_test <- function(path_default_nix) {
+
+    rix(r_ver = "3.5.3",
+        ide = "other",
+        r_pkgs = NULL,
+        project_path = path_default_nix,
+        overwrite = TRUE,
+        shell_hook = NULL
+      )
+
+    paste0(path_default_nix, "/default.nix")
+
+  }
+
+  testthat::expect_warning(
+    save_default_nix_test(path_default_nix),
+    regexp = "older version of R"
+  )
+
+})
+
 testthat::test_that("rix(), bleeding_edge", {
 
   path_default_nix <- tempdir()

--- a/tests/testthat/test-rix.R
+++ b/tests/testthat/test-rix.R
@@ -209,6 +209,30 @@ testthat::test_that("If R version is 4.4.0, raise warning", {
 
 })
 
+testthat::test_that("If R version is <= 4.1.1, raise warning", {
+
+  path_default_nix <- tempdir()
+
+  save_default_nix_test <- function(path_default_nix) {
+
+    rix(r_ver = "4.1.1",
+        ide = "other",
+        r_pkgs = NULL,
+        project_path = path_default_nix,
+        overwrite = TRUE,
+        shell_hook = NULL
+      )
+
+    paste0(path_default_nix, "/default.nix")
+
+  }
+
+  testthat::expect_warning(
+    save_default_nix_test(path_default_nix),
+    regexp = "older version of R"
+  )
+
+})
 
 testthat::test_that("rix(), bleeding_edge", {
 

--- a/tests/testthat/test-with_nix.R
+++ b/tests/testthat/test-with_nix.R
@@ -20,11 +20,15 @@ testthat::test_that("Testing `with_nix()` if Nix is installed", {
     message_type = "simple"
   )
 
-  rix(
-    r_ver = "3.5.3",
-    overwrite = TRUE,
-    project_path = path_subshell,
-    shell_hook = NULL
+  # Suppress the warning related to generating an expression
+  # for an old version of R
+  suppressWarnings(
+    rix(
+      r_ver = "3.5.3",
+      overwrite = TRUE,
+      project_path = path_subshell,
+      shell_hook = NULL
+    )
   )
 
   out_subshell <- with_nix(

--- a/vignettes/a-getting-started.Rmd
+++ b/vignettes/a-getting-started.Rmd
@@ -91,7 +91,7 @@ versions of R and R packages that you need. Suppose that you start working on a
 new project. As you start the project, with Nix, you would install a
 project-specific version of R and R packages that you would only use for that
 particular project. If you switch projects, you'd switch versions of R and R
-packages. 
+packages.
 
 If you are familiar with `{renv}`, you should see that this is exactly
 the same thing: the difference is that not only will you have a project-specific
@@ -121,7 +121,6 @@ will get exactly, byte by byte, the same environment as you when you initially
 started the project. And this also regardless of the operating system that is
 used.
 
-
 ## The Nix package manager
 
 Nix is a package manager that can be installed on your computer (regardless of
@@ -131,26 +130,27 @@ you're familiar with the Ubuntu Linux distribution, you likely have used
 similar purposes. Nix functions in a similar way, but has many advantages over
 classic package managers. The main advantage of Nix, at least for our purposes,
 is that its repository of software is huge. As of writing, it contains more than
-80.000 packages, and the entirety of CRAN and Bioconductor is available through
-Nix's repositories. 
+100.000 packages, and the entirety of CRAN and Bioconductor is available through
+Nix's repositories.
 
-This means that using Nix, it is possible to install not
-only R, but also all the packages required for your project. The obvious
-question is why use Nix instead of simply installing R and R packages as usual.
-The answer is that Nix makes sure to install every dependency of any package, up
-to required system libraries. For example, the `{xlsx}` package requires the
-Java programming language to be installed on your computer to successfully
-install. This can be difficult to achieve, and `{xlsx}` bullied many R
-developers throughout the years (especially those using a Linux distribution,
-`sudo R CMD javareconf` still plagues my nightmares). 
+This means that using Nix, it is possible to install not only R, but also all
+the packages required for your project. The obvious question is why use Nix
+instead of simply installing R and R packages as usual. The answer is that Nix
+makes sure to install every dependency of any package, up to required system
+libraries. For example, the `{xlsx}` package requires the Java programming
+language to be installed on your computer to successfully install. This can be
+difficult to achieve, and `{xlsx}` bullied many R developers throughout the
+years (especially those using a Linux distribution, `sudo R CMD javareconf`
+still plagues my nightmares).
 
-But with Nix, it suffices to declare that we want the `{xlsx}` package for our project, and Nix figures
-out automatically that Java is required and installs and configures it. It all
-just happens without any required intervention from the user. The second
-advantage of Nix is that it is possible to *pin* a certain *revision* of the Nix
-packages' repository (called `nixpkgs`) for our project. Pinning a revision
-ensures that every package that Nix installs will always be at exactly the same
-versions, regardless of when in the future the packages get installed.
+But with Nix, it suffices to declare that we want the `{xlsx}` package for our
+project, and Nix figures out automatically that Java is required and installs
+and configures it. It all just happens without any required intervention from
+the user. The second advantage of Nix is that it is possible to *pin* a certain
+*revision* of the Nix packages' repository (called `nixpkgs`) for our project.
+Pinning a revision ensures that every package that Nix installs will always be
+at exactly the same versions, regardless of when in the future the packages get
+installed.
 
 ## rix workflow
 
@@ -165,15 +165,14 @@ not get re-installed to save space. Environments are isolated for each other,
 but can still interact with your system's files, unlike with Docker where a
 volume must be mounted. Environments can also interact with the software
 installed on your computer through the usual means, which can sometimes lead to
-issues. For example, if you already have R installed, and a user library
-of R packages, more caution is required to properly use environments managed
-by Nix. 
+issues. For example, if you already have R installed, and a user library of R
+packages, more caution is required to properly use environments managed by Nix.
 
 It is important at this stage to understand that you should not call
-`install.packages()` from a running Nix environment. If you want to add
-packages to a Nix environment while analyzing data, you need to add it the `default.nix` 
-expression and rebuild the environment. This is explained in greater detail
-in `vignette("d1-installing-r-packages-in-a-nix-environment")`.
+`install.packages()` from a running Nix environment. If you want to add packages
+to a Nix environment while analyzing data, you need to add it the `default.nix`
+expression and rebuild the environment. This is explained in greater detail in
+`vignette("d1-installing-r-packages-in-a-nix-environment")`.
 
 To avoid interference between your main R library of packages and your
 Nix environments, we recommend you read the documentation of `rix_init()`.
@@ -223,6 +222,9 @@ function in a terminal:
 nix-build
 ```
 
+Nix install packages in a dedicated folder on your computer, called the *Nix
+store*.
+
 Once Nix is done building the environment, you can start working on it
 interactively by using the following command in a terminal emulator (not the R
 console):
@@ -231,11 +233,23 @@ console):
 nix-shell
 ```
 
-You will *drop* into a Nix shell which provides the installed software.
+You will *drop* into a Nix shell which provides the installed software. It is not
+mandatory to call `nix-build` first: you can immediately call `nix-shell`. The
+advantage of using `nix-build` first is that it create a file called `result`
+which will prevent the environment to get garbage collected if you clean
+the Nix store.
 
-If you want to completely isolate your Nix environment from the rest of 
-the system, we recommend using `nix-shell --pure` to drop into the environment,
-as described in the documentation of `rix_init()`.
+If you want to build an environment for an older version of R, you might get a
+warning telling you that you cannot build the expression, but that you can
+directly drop into it.
+
+If you want to completely isolate your Nix environment from the rest of the
+system, we recommend using `nix-shell --pure` to drop into the environment, as
+described in the documentation of `rix_init()`.
+
+Finally, if you want to delete an environment, delete the `result` file first
+(if you used `nix-build`) and then call `nix-store --gc`, which will delete all
+the orphaned packages.
 
 Now that you know more about Nix and `{rix}`, it is time to get these tools
 installed on your system.


### PR DESCRIPTION
For older versions of R, shells could not be built, instead users have to drop into them directly. This is to warn users about that.